### PR TITLE
fixed layout bug

### DIFF
--- a/components/collection/Index.js
+++ b/components/collection/Index.js
@@ -154,7 +154,7 @@ export default function Collection({route}) {
           {collection.length !== 0 ? (
             pairCollection
           ) : (
-            <Text>No collection yet.</Text>
+            <Text style={styles.waifuNemeText}> No collection yet.</Text>
           )}
         </ScrollView>
       </Body>
@@ -174,6 +174,7 @@ const styles = StyleSheet.create({
   },
   body: {
     backgroundColor: COLORS.textSecondary,
+    width: '100%',
   },
   showView: {
     height: hp('52%'),


### PR DESCRIPTION
I fixed the layout bug.
When there are a couple of collections, the collection arranged center.
-> I changed left-justified.
When there is no collection, the font is black and the background is dark-gray.
-> I changed the font color.

I'm sorry, I didn't care about them yesterday.