### PR TITLE
fix app crash on removal bug

### DIFF
--- a/components/collection/DetailFooter.js
+++ b/components/collection/DetailFooter.js
@@ -18,9 +18,9 @@ export default function DetailHeader({navigation}) {
     const waifu = waifus[selectedIndex];
     utils.sellWaifu(waifu.malId).then(result => {
       navigation.pop();
+      setSelectedIndex(0);
       setWaifus(waifus.filter(x => x.id !== waifu.id));
       incrementGems(result);
-      setSelectedIndex(0);
       popUpWaifu({
         waifu: null,
         gems: result,


### PR DESCRIPTION
- changed character deletion to only return to collections page after the selected index has been updated (otherwise it tries displaying a character that no longer exists)